### PR TITLE
Offline Radiator Check

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -14,7 +14,7 @@ export class ADAXPlatformAccessory {
 
   constructor(
     private readonly platform: ADAXHomebridgePlatform,
-    private readonly accessory: PlatformAccessory
+    private readonly accessory: PlatformAccessory,
   ) {
     this.accessory
       .getService(this.platform.Service.AccessoryInformation)!
@@ -28,12 +28,12 @@ export class ADAXPlatformAccessory {
 
     this.service.setCharacteristic(
       this.platform.Characteristic.Name,
-      accessory.context.device.name
+      accessory.context.device.name,
     );
 
     this.service
       .getCharacteristic(
-        this.platform.Characteristic.CurrentHeatingCoolingState
+        this.platform.Characteristic.CurrentHeatingCoolingState,
       )
       .on('get', this.handleCurrentHeatingCoolingStateGet.bind(this));
 


### PR DESCRIPTION
This pull request should fix issue #2 where the plugin would cause HomeBridge to crash if a heater was turned off or could not be connected to. The following changes have been made.

- Updated the heater status to allow 'OFF' to be used.
- Added a 'try->catch' block around the temperature handling blocks if an error is thrown from the 'precision' method instead of crashing out it simply marks the heater as 'OFF'